### PR TITLE
Add Nginx reverse proxy on port 11380

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  db: 
+  db:
     image: mysql:latest
     environment:
       - MYSQL_DATABASE=php_docker
@@ -23,3 +23,12 @@ services:
     environment:
       - PMA_HOST=db
       - PMA_PORT=3306
+
+  nginx:
+    image: nginx:latest
+    ports:
+      - "11380:11380"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - www

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 11380;
+    server_name smart-bin.camt.cmu.ac.th;
+
+    location / {
+        proxy_pass http://www:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- Add Nginx service and configuration for smart-bin.camt.cmu.ac.th
- Map public port 11380 to the PHP Apache service via Nginx

## Testing
- `docker-compose config` *(fails: command not found)*
- `pip install docker-compose` *(fails: Could not find a version that satisfies the requirement docker-compose)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a14a14b924833187e4be93f1b62895