### PR TITLE
feat: support arm64 deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.8"
 
 services:
   db:
+    platform: linux/arm64/v8
     image: mysql:8.4
     command: --default-authentication-plugin=mysql_native_password
     environment:
@@ -12,7 +13,7 @@ services:
     volumes:
       - db_data:/var/lib/mysql
       # โหลดสคริปต์ init จากโฟลเดอร์ใน repo (ไม่ใช่พาธ host แปลก ๆ)
-      - ./initdb:/docker-entrypoint-initdb.d:ro
+      - ./db:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-p${MYSQL_ROOT_PASSWORD:-rootpass}"]
       interval: 10s
@@ -21,6 +22,7 @@ services:
     networks: [app]
 
   www:
+    platform: linux/arm64/v8
     build:
       context: .
       dockerfile: Dockerfile
@@ -40,6 +42,7 @@ services:
     networks: [app]
 
   phpmyadmin:
+    platform: linux/arm64/v8
     image: phpmyadmin/phpmyadmin:latest
     depends_on:
       db:


### PR DESCRIPTION
## Summary
- ensure MySQL, PHP, and phpMyAdmin services build with `linux/arm64/v8`
- fix MySQL init volume path to use repo `db` directory

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ace08c50833199965c728f6531c5