### PR TITLE
fix: allow portainer stack deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3.8"
 
 services:
   db:
-    platform: linux/arm64/v8
     image: mysql:8.4
     command: --default-authentication-plugin=mysql_native_password
     environment:
@@ -22,7 +21,6 @@ services:
     networks: [app]
 
   www:
-    platform: linux/arm64/v8
     build:
       context: .
       dockerfile: Dockerfile
@@ -42,7 +40,6 @@ services:
     networks: [app]
 
   phpmyadmin:
-    platform: linux/arm64/v8
     image: phpmyadmin/phpmyadmin:latest
     depends_on:
       db:


### PR DESCRIPTION
## Summary
- remove platform constraints from all services in docker-compose

## Testing
- `docker-compose config -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b50f073c83319443c8f7e41dd2ad